### PR TITLE
Add a rule to remove the line breaks before the equal sign. fixes #19

### DIFF
--- a/lib/args/args.dart
+++ b/lib/args/args.dart
@@ -15,6 +15,7 @@ import '../rule/indentation.dart';
 import '../rule/no_consecutive_empty_lines.dart';
 import '../rule/no_empty_indentation.dart';
 import '../rule/no_empty_lines_between_imports.dart';
+import '../rule/no_line_breaks_before_equal.dart';
 import '../rule/no_trailing_spaces.dart';
 import '../rule/rule.dart';
 import '../rule/spaces_in_for.dart';
@@ -115,6 +116,7 @@ class Args {
         SpacesInFor(log),
         SpacesInWhile(log),
         SpacesInSwitch(log),
+        NoLineBreaksBeforeEqual(log),
         Indentation(log),
         EmptyLineAtEnd(log)
       ],

--- a/lib/rule/no_line_breaks_before_equal.dart
+++ b/lib/rule/no_line_breaks_before_equal.dart
@@ -1,0 +1,60 @@
+/// Copyright (c) 2020 Rin (https://www.levelrin.com)
+/// This file has been created under the terms of the MIT License.
+/// See the details at https://github.com/levelrin/DartStyleRin/blob/master/LICENSE
+
+import '../feedback/feedback.dart';
+import '../line/line.dart';
+import '../log/log.dart';
+import '../source/source.dart';
+import 'rule.dart';
+
+/// It checks the code it there are some line breaks before the equal (=) sign.
+/// For example,
+/// ```dart
+/// final String one
+/// = 'one';
+/// ```
+/// The above should be:
+/// ```dart
+/// final String one = 'one';
+/// ```
+class NoLineBreaksBeforeEqual implements Rule {
+
+  /// Constructor.
+  const NoLineBreaksBeforeEqual(this._log);
+
+  /// For logging.
+  final Log _log;
+
+  @override
+  List<Feedback> check(final Source source) {
+    _log.debug(this, 'check()', 'Start checking the line breaks before the equal sign.');
+    final List<Feedback> feedbackList = <Feedback>[];
+    for (final Line line in source.lines()) {
+      final String text = line.text();
+      if (text.trimLeft().startsWith('=')) {
+        feedbackList.add(
+          Feedback(
+            line,
+            'Line breaks are not allowed before the equal sign.',
+            _log
+          )
+        );
+      }
+    }
+    _log.debug(this, 'check()', 'End checking the line breaks before the equal sign.');
+    return feedbackList;
+  }
+
+  @override
+  Source format(final Source source) {
+    return Source(
+      source.toString().replaceAll(
+        RegExp(r'\n\s*=', multiLine: false),
+        ' ='
+      ),
+      _log
+    );
+  }
+
+}

--- a/test/rule/no_line_breaks_before_equal/invalid.txt
+++ b/test/rule/no_line_breaks_before_equal/invalid.txt
@@ -1,0 +1,12 @@
+const String apple
+ = 'Apple';
+
+final int banana
+ = 1;
+
+Type type
+ = Type(
+  param1,
+  param2,
+  param3
+);

--- a/test/rule/no_line_breaks_before_equal/no_line_breaks_before_equal_test.dart
+++ b/test/rule/no_line_breaks_before_equal/no_line_breaks_before_equal_test.dart
@@ -1,0 +1,54 @@
+/// Copyright (c) 2020 Rin (https://www.levelrin.com)
+/// This file has been created under the terms of the MIT License.
+/// See the details at https://github.com/levelrin/DartStyleRin/blob/master/LICENSE
+
+import 'dart:io' as io;
+import 'package:dart_style_rin/log/silent_log.dart';
+import 'package:dart_style_rin/rule/no_line_breaks_before_equal.dart';
+import 'package:dart_style_rin/source/source.dart';
+import 'package:test/test.dart';
+
+void main() {
+
+  /// Invalid content.
+  String invalid;
+
+  /// Valid content.
+  String valid;
+
+  setUpAll(() {
+    invalid = io.File('test/rule/no_line_breaks_before_equal/invalid.txt').readAsStringSync();
+    valid = io.File('test/rule/no_line_breaks_before_equal/valid.txt').readAsStringSync();
+  });
+
+  group('NoLineBreaksBeforeEqual', () {
+    test('.check() should give feedback if there is a line break before the equal sign.', () {
+      final SilentLog log = SilentLog();
+      expect(
+        NoLineBreaksBeforeEqual(log).check(
+          Source(invalid, log)
+        ).length,
+        greaterThan(0)
+      );
+    });
+    test('.check() should not give feedback if there is no line break before the equal sign.', () {
+      final SilentLog log = SilentLog();
+      expect(
+        NoLineBreaksBeforeEqual(log).check(
+          Source(valid, log)
+        ).length,
+        0
+      );
+    });
+    test('.format() should remove line breaks before the equal sign.', () {
+      final SilentLog log = SilentLog();
+      expect(
+        NoLineBreaksBeforeEqual(log).format(
+          Source(invalid, log)
+        ),
+        Source(valid, log)
+      );
+    });
+  });
+
+}

--- a/test/rule/no_line_breaks_before_equal/valid.txt
+++ b/test/rule/no_line_breaks_before_equal/valid.txt
@@ -1,0 +1,9 @@
+const String apple = 'Apple';
+
+final int banana = 1;
+
+Type type = Type(
+  param1,
+  param2,
+  param3
+);


### PR DESCRIPTION
https://github.com/levelrin/DartStyleRin/issues/19